### PR TITLE
OCR scaffold + unit tests for catalog conversions

### DIFF
--- a/src/health_report/cli.py
+++ b/src/health_report/cli.py
@@ -33,7 +33,12 @@ def main():
     data_dir = Path(cfg["data_dir"]).resolve()
     ensure_dirs([out_dir, data_dir])
 
-    extracted = extract_from_reports(reports_dir, data_dir, cache=cfg.get("parsing", {}).get("cache", True))
+    extracted = extract_from_reports(
+        reports_dir,
+        data_dir,
+        cache=cfg.get("parsing", {}).get("cache", True),
+        ocr=cfg.get("ocr", {}),
+    )
     normalized = normalize_measurements(extracted, data_dir, units_preference=cfg.get("units_preference", "auto"))
     trends = compute_trends(normalized, rolling_window_days=cfg.get("analytics", {}).get("rolling_window_days", 120))
     scored = compute_scores(trends)
@@ -50,4 +55,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/health_report/extract/pdf_parser.py
+++ b/src/health_report/extract/pdf_parser.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Optional, Set
+import itertools
+import logging
 import re
 import pdfplumber
 
 from ..utils.io import read_json, write_json
-from ..utils.ocr import ocr_page
+from ..utils.ocr import ocr_page, DEFAULT_OCR_DPI, DEFAULT_OCR_LANGS
 
 
 EXTRACT_CACHE = "extracted.json"
+MIN_TEXT_LEN_FOR_OCR = 20
 
 
 def extract_from_reports(reports_dir: Path, data_dir: Path, cache: bool = True, ocr: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
@@ -20,9 +23,8 @@ def extract_from_reports(reports_dir: Path, data_dir: Path, cache: bool = True, 
             return cached
 
     results: List[Dict[str, Any]] = []
-    for pdf_path in sorted(reports_dir.rglob("*.pdf")):
-        results.extend(extract_from_pdf(pdf_path, ocr=ocr))
-    for pdf_path in sorted(reports_dir.rglob("*.PDF")):
+    pdf_files = [p for p in reports_dir.rglob("*") if p.is_file() and p.suffix.lower() == ".pdf"]
+    for pdf_path in sorted(pdf_files):
         results.extend(extract_from_pdf(pdf_path, ocr=ocr))
 
     if cache:
@@ -53,9 +55,10 @@ def extract_from_pdf(pdf_path: Path, ocr: Optional[Dict[str, Any]] = None) -> Li
                 # 2) Also parse raw text lines to catch non-table content
                 text = page.extract_text() or ""
                 # If OCR is enabled and text is very short, attempt OCR
-                if (not text or len(text) < 20) and ocr and ocr.get("enabled"):
-                    dpi = int(ocr.get("dpi", 200))
-                    langs = ocr.get("languages", "eng")
+                if (not text or len(text) < MIN_TEXT_LEN_FOR_OCR) and ocr and ocr.get("enabled"):
+                    dpi = int(ocr.get("dpi", DEFAULT_OCR_DPI))
+                    langs = ocr.get("languages", DEFAULT_OCR_LANGS)
+                    logging.debug("Attempting OCR for %s page %s (dpi=%s, langs=%s)", pdf_path.name, pi, dpi, langs)
                     text_ocr = ocr_page(pdf_path, pi, dpi=dpi, languages=langs)
                     if text_ocr:
                         text = text_ocr

--- a/src/health_report/extract/pdf_parser.py
+++ b/src/health_report/extract/pdf_parser.py
@@ -6,12 +6,13 @@ import re
 import pdfplumber
 
 from ..utils.io import read_json, write_json
+from ..utils.ocr import ocr_page
 
 
 EXTRACT_CACHE = "extracted.json"
 
 
-def extract_from_reports(reports_dir: Path, data_dir: Path, cache: bool = True) -> List[Dict[str, Any]]:
+def extract_from_reports(reports_dir: Path, data_dir: Path, cache: bool = True, ocr: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
     cache_path = data_dir / EXTRACT_CACHE
     if cache and cache_path.exists():
         cached = read_json(cache_path, default=[])
@@ -20,21 +21,21 @@ def extract_from_reports(reports_dir: Path, data_dir: Path, cache: bool = True) 
 
     results: List[Dict[str, Any]] = []
     for pdf_path in sorted(reports_dir.rglob("*.pdf")):
-        results.extend(extract_from_pdf(pdf_path))
+        results.extend(extract_from_pdf(pdf_path, ocr=ocr))
     for pdf_path in sorted(reports_dir.rglob("*.PDF")):
-        results.extend(extract_from_pdf(pdf_path))
+        results.extend(extract_from_pdf(pdf_path, ocr=ocr))
 
     if cache:
         write_json(cache_path, results)
     return results
 
 
-def extract_from_pdf(pdf_path: Path) -> List[Dict[str, Any]]:
+def extract_from_pdf(pdf_path: Path, ocr: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
     rows: List[Dict[str, Any]] = []
     seen: Set[Tuple[str, str, str]] = set()  # (file, name_lower, value_raw)
     try:
         with pdfplumber.open(pdf_path) as pdf:
-            for page in pdf.pages:
+            for pi, page in enumerate(pdf.pages):
                 # 1) Parse any table-like blocks by treating cells as text lines
                 tables = page.extract_tables() or []
                 for tbl in tables:
@@ -51,6 +52,13 @@ def extract_from_pdf(pdf_path: Path) -> List[Dict[str, Any]]:
 
                 # 2) Also parse raw text lines to catch non-table content
                 text = page.extract_text() or ""
+                # If OCR is enabled and text is very short, attempt OCR
+                if (not text or len(text) < 20) and ocr and ocr.get("enabled"):
+                    dpi = int(ocr.get("dpi", 200))
+                    langs = ocr.get("languages", "eng")
+                    text_ocr = ocr_page(pdf_path, pi, dpi=dpi, languages=langs)
+                    if text_ocr:
+                        text = text_ocr
                 for rec in _parse_result_lines([ln.strip() for ln in text.splitlines() if ln.strip()], pdf_path):
                     key = (rec["file"], rec["test_name"].lower(), rec.get("value_raw", ""))
                     if key not in seen:

--- a/src/health_report/utils/ocr.py
+++ b/src/health_report/utils/ocr.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+def ocr_page(pdf_path: Path, page_index: int, *, dpi: int = 200, languages: str = "eng") -> str:
+    """Render a single PDF page to an image and run Tesseract OCR.
+
+    Returns empty string if OCR dependencies are unavailable.
+    - page_index is zero-based.
+    """
+    try:
+        import pypdfium2 as pdfium  # type: ignore
+    except Exception:
+        return ""
+    try:
+        import pytesseract  # type: ignore
+    except Exception:
+        return ""
+
+    try:
+        pdf = pdfium.PdfDocument(str(pdf_path))
+        if page_index < 0 or page_index >= len(pdf):
+            return ""
+        page = pdf.get_page(page_index)
+        bitmap = page.render(scale=dpi / 72.0).to_pil()
+        text = pytesseract.image_to_string(bitmap, lang=languages) or ""
+        return text
+    except Exception:
+        return ""
+

--- a/src/health_report/utils/ocr.py
+++ b/src/health_report/utils/ocr.py
@@ -1,22 +1,31 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Optional
 
 
-def ocr_page(pdf_path: Path, page_index: int, *, dpi: int = 200, languages: str = "eng") -> str:
+DEFAULT_OCR_DPI = 200
+DEFAULT_OCR_LANGS = "eng"
+
+
+def ocr_page(
+    pdf_path: Path,
+    page_index: int,
+    *,
+    dpi: int = DEFAULT_OCR_DPI,
+    languages: str = DEFAULT_OCR_LANGS,
+) -> str:
     """Render a single PDF page to an image and run Tesseract OCR.
 
-    Returns empty string if OCR dependencies are unavailable.
+    Returns empty string if OCR dependencies are unavailable or an error occurs.
     - page_index is zero-based.
     """
     try:
         import pypdfium2 as pdfium  # type: ignore
-    except Exception:
-        return ""
-    try:
         import pytesseract  # type: ignore
-    except Exception:
+    except ImportError as e:
+        logging.debug("OCR dependencies not available: %s", e)
         return ""
 
     try:
@@ -27,6 +36,6 @@ def ocr_page(pdf_path: Path, page_index: int, *, dpi: int = 200, languages: str 
         bitmap = page.render(scale=dpi / 72.0).to_pil()
         text = pytesseract.image_to_string(bitmap, lang=languages) or ""
         return text
-    except Exception:
+    except Exception as e:
+        logging.warning(f"OCR for {pdf_path.name} page {page_index} failed: {e}")
         return ""
-

--- a/tests/test_catalog_units.py
+++ b/tests/test_catalog_units.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def load_catalog() -> dict:
+    path = Path("data/metrics_catalog.json")
+    assert path.exists(), "metrics_catalog.json is missing"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_bun_conversions():
+    tests = load_catalog()["tests"]
+    bun = tests["BUN"]
+    conv = bun["conversions"]
+    assert conv.get("mg/dL->mmol/L") == 0.357
+    assert conv.get("mmol/L->mg/dL") == 2.8
+
+
+def test_creatinine_conversions():
+    tests = load_catalog()["tests"]
+    cr = tests["CREATININE"]
+    conv = cr["conversions"]
+    assert conv.get("mg/dL->umol/L") == 88.4
+    assert round(conv.get("umol/L->mg/dL"), 5) == 0.01131
+    aliases = set(cr["unit_aliases"])
+    assert {"umol/L", "µmol/L"}.issubset(aliases)
+
+
+def test_electrolyte_aliases():
+    tests = load_catalog()["tests"]
+    for code in ["SODIUM", "POTASSIUM", "CHLORIDE", "CARBON_DIOXIDE"]:
+        t = tests[code]
+        assert "mEq/L" in t["unit_aliases"]
+        conv = t["conversions"]
+        assert conv.get("mEq/L->mmol/L") == 1.0
+        assert conv.get("mmol/L->mEq/L") == 1.0
+
+
+def test_calcium_conversions():
+    tests = load_catalog()["tests"]
+    ca = tests["CALCIUM"]
+    conv = ca["conversions"]
+    assert conv.get("mg/dL->mmol/L") == 0.25
+    assert conv.get("mmol/L->mg/dL") == 4.0
+
+
+def test_protein_conversions():
+    tests = load_catalog()["tests"]
+    for code in ["PROTEIN_TOTAL", "ALBUMIN", "GLOBULIN"]:
+        t = tests[code]
+        conv = t["conversions"]
+        assert conv.get("g/dL->g/L") == 10.0
+        assert conv.get("g/L->g/dL") == 0.1
+
+
+def test_bilirubin_conversions():
+    tests = load_catalog()["tests"]
+    for code in ["BILIRUBIN_TOTAL", "BILIRUBIN_DIRECT", "BILIRUBIN_INDIRECT"]:
+        t = tests[code]
+        conv = t["conversions"]
+        assert conv.get("mg/dL->umol/L") == 17.1
+        assert round(conv.get("umol/L->mg/dL"), 4) == 0.0585
+
+
+def test_unitless_alias_arrays():
+    tests = load_catalog()["tests"]
+    for code in ["CHOL_HDL_RATIO", "LDL_HDL_RATIO", "A_G_RATIO"]:
+        assert tests[code]["unit_aliases"] == []
+

--- a/tests/test_catalog_units.py
+++ b/tests/test_catalog_units.py
@@ -2,24 +2,27 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import pytest
 
 
-def load_catalog() -> dict:
-    path = Path("data/metrics_catalog.json")
-    assert path.exists(), "metrics_catalog.json is missing"
+@pytest.fixture(scope="module")
+def catalog() -> dict:
+    # Resolve path relative to repository root (tests/ is at repo root)
+    repo_root = Path(__file__).resolve().parents[1]
+    path = repo_root / "data" / "metrics_catalog.json"
+    assert path.exists(), f"Missing catalog at {path}"
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def test_bun_conversions():
-    tests = load_catalog()["tests"]
+def test_bun_conversions(catalog: dict):
+    tests = catalog["tests"]
     bun = tests["BUN"]
     conv = bun["conversions"]
     assert conv.get("mg/dL->mmol/L") == 0.357
     assert conv.get("mmol/L->mg/dL") == 2.8
 
-
-def test_creatinine_conversions():
-    tests = load_catalog()["tests"]
+def test_creatinine_conversions(catalog: dict):
+    tests = catalog["tests"]
     cr = tests["CREATININE"]
     conv = cr["conversions"]
     assert conv.get("mg/dL->umol/L") == 88.4
@@ -27,9 +30,8 @@ def test_creatinine_conversions():
     aliases = set(cr["unit_aliases"])
     assert {"umol/L", "µmol/L"}.issubset(aliases)
 
-
-def test_electrolyte_aliases():
-    tests = load_catalog()["tests"]
+def test_electrolyte_aliases(catalog: dict):
+    tests = catalog["tests"]
     for code in ["SODIUM", "POTASSIUM", "CHLORIDE", "CARBON_DIOXIDE"]:
         t = tests[code]
         assert "mEq/L" in t["unit_aliases"]
@@ -37,35 +39,30 @@ def test_electrolyte_aliases():
         assert conv.get("mEq/L->mmol/L") == 1.0
         assert conv.get("mmol/L->mEq/L") == 1.0
 
-
-def test_calcium_conversions():
-    tests = load_catalog()["tests"]
+def test_calcium_conversions(catalog: dict):
+    tests = catalog["tests"]
     ca = tests["CALCIUM"]
     conv = ca["conversions"]
     assert conv.get("mg/dL->mmol/L") == 0.25
     assert conv.get("mmol/L->mg/dL") == 4.0
 
-
-def test_protein_conversions():
-    tests = load_catalog()["tests"]
+def test_protein_conversions(catalog: dict):
+    tests = catalog["tests"]
     for code in ["PROTEIN_TOTAL", "ALBUMIN", "GLOBULIN"]:
         t = tests[code]
         conv = t["conversions"]
         assert conv.get("g/dL->g/L") == 10.0
         assert conv.get("g/L->g/dL") == 0.1
 
-
-def test_bilirubin_conversions():
-    tests = load_catalog()["tests"]
+def test_bilirubin_conversions(catalog: dict):
+    tests = catalog["tests"]
     for code in ["BILIRUBIN_TOTAL", "BILIRUBIN_DIRECT", "BILIRUBIN_INDIRECT"]:
         t = tests[code]
         conv = t["conversions"]
         assert conv.get("mg/dL->umol/L") == 17.1
         assert round(conv.get("umol/L->mg/dL"), 4) == 0.0585
 
-
-def test_unitless_alias_arrays():
-    tests = load_catalog()["tests"]
+def test_unitless_alias_arrays(catalog: dict):
+    tests = catalog["tests"]
     for code in ["CHOL_HDL_RATIO", "LDL_HDL_RATIO", "A_G_RATIO"]:
         assert tests[code]["unit_aliases"] == []
-


### PR DESCRIPTION
Implements an optional OCR path (scaffold) and adds a small unit test file for catalog conversions/aliases.\n\nOCR (issue #3)\n- Passes  config from CLI to extractor\n- If  and a page has little/no text, render via  and run Tesseract () when available\n- Gracefully no-op if dependencies are missing\n\nTests\n- Adds  verifying conversion keys and aliases for BUN, Creatinine, electrolytes, Calcium, Proteins, Bilirubin, and unitless metrics\n\nNotes\n- No changes to requirements; OCR remains optional and off by default\n- Privacy preserved (reports/ and build/ ignored)\n\nLinks: closes #3 when OCR is fully implemented; partial scaffold here.