### PR TITLE
feat: add configurable OCR fallback for scanned PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,20 @@ Edit `config.yaml` to change defaults:
 - `analytics.*`: Simple trend and volatility settings.
 - `report.title`, `report.favorites`: Dashboard options.
 
-Notes:
-- OCR: Not enabled/implemented; PDFs must be text‑based (selectable text). Scanned images will not extract values.
+### OCR
+The extractor can fall back to Tesseract OCR for scanned PDFs. Ensure the
+system `tesseract-ocr` binary is installed. Configure in `config.yaml`:
+
+```
+ocr:
+  enabled: false
+  mode: auto       # auto | always | never
+  dpi: 200
+  languages: eng   # comma-separated Tesseract language codes
+```
+
+OCR settings can also be overridden via CLI flags such as
+`--enable-ocr`, `--ocr-mode`, `--ocr-dpi`, and `--ocr-langs`.
 
 ## Supported PDF Format
 - Optimized for Quest Diagnostics reports where result lines look like:
@@ -65,7 +77,7 @@ Notes:
 
 ## Troubleshooting
 - Dashboard shows "No data":
-  - Ensure your PDFs contain selectable text (not scanned images).
+  - If pages are scanned images, enable OCR via `--enable-ocr` or the `ocr` section in `config.yaml`.
   - Verify lines include "Reference Range:"; other vendor formats may require tuning.
   - Clear caches and re‑run:
     - Windows: `del data\extracted.json data\normalized.json`

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,9 @@ privacy:
   relative_dates: false
 ocr:
   enabled: false
+  mode: auto  # auto | always | never
+  dpi: 200
+  languages: eng
 parsing:
   cache: true
   parallel_workers: 4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ PyYAML==6.0.2
 python-dateutil==2.9.0.post0
 scipy==1.13.1
 beautifulsoup4==4.12.3
+pypdfium2==4.30.0
+pytesseract==0.3.10

--- a/src/health_report/cli.py
+++ b/src/health_report/cli.py
@@ -16,6 +16,10 @@ def main():
     parser.add_argument("--out-dir", default=None, help="Output directory for HTML report")
     parser.add_argument("--data-dir", default=None, help="Data dir for caches")
     parser.add_argument("--units", default=None, choices=["auto", "canonical", "original"], help="Units handling mode")
+    parser.add_argument("--enable-ocr", action="store_true", help="Enable OCR for scanned PDFs")
+    parser.add_argument("--ocr-mode", choices=["auto", "always", "never"], default=None, help="When to apply OCR")
+    parser.add_argument("--ocr-dpi", type=int, default=None, help="Rendering DPI for OCR")
+    parser.add_argument("--ocr-langs", default=None, help="Tesseract language codes")
     args = parser.parse_args()
 
     cfg = load_config()
@@ -27,6 +31,14 @@ def main():
         cfg["data_dir"] = args.data_dir
     if args.units:
         cfg["units_preference"] = args.units
+    if args.enable_ocr:
+        cfg.setdefault("ocr", {})["enabled"] = True
+    if args.ocr_mode:
+        cfg.setdefault("ocr", {})["mode"] = args.ocr_mode
+    if args.ocr_dpi is not None:
+        cfg.setdefault("ocr", {})["dpi"] = args.ocr_dpi
+    if args.ocr_langs:
+        cfg.setdefault("ocr", {})["languages"] = args.ocr_langs
 
     reports_dir = Path(cfg["reports_dir"]).resolve()
     out_dir = Path(cfg["out_dir"]).resolve()

--- a/src/health_report/extract/pdf_parser.py
+++ b/src/health_report/extract/pdf_parser.py
@@ -12,7 +12,6 @@ from ..utils.ocr import ocr_page, DEFAULT_OCR_DPI, DEFAULT_OCR_LANGS
 
 
 EXTRACT_CACHE = "extracted.json"
-MIN_TEXT_LEN_FOR_OCR = 20
 
 
 def extract_from_reports(reports_dir: Path, data_dir: Path, cache: bool = True, ocr: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
@@ -54,14 +53,29 @@ def extract_from_pdf(pdf_path: Path, ocr: Optional[Dict[str, Any]] = None) -> Li
 
                 # 2) Also parse raw text lines to catch non-table content
                 text = page.extract_text() or ""
-                # If OCR is enabled and text is very short, attempt OCR
-                if (not text or len(text) < MIN_TEXT_LEN_FOR_OCR) and ocr and ocr.get("enabled"):
-                    dpi = int(ocr.get("dpi", DEFAULT_OCR_DPI))
-                    langs = ocr.get("languages", DEFAULT_OCR_LANGS)
-                    logging.debug("Attempting OCR for %s page %s (dpi=%s, langs=%s)", pdf_path.name, pi, dpi, langs)
-                    text_ocr = ocr_page(pdf_path, pi, dpi=dpi, languages=langs)
-                    if text_ocr:
-                        text = text_ocr
+                if ocr and ocr.get("enabled"):
+                    mode = str(ocr.get("mode", "auto")).lower()
+                    need_ocr = mode == "always" or (mode == "auto" and not text)
+                    if need_ocr:
+                        dpi = int(ocr.get("dpi", DEFAULT_OCR_DPI))
+                        langs = ocr.get("languages", DEFAULT_OCR_LANGS)
+                        t_cmd = ocr.get("tesseract_cmd")
+                        logging.debug(
+                            "Attempting OCR for %s page %s (dpi=%s, langs=%s)",
+                            pdf_path.name,
+                            pi,
+                            dpi,
+                            langs,
+                        )
+                        text_ocr = ocr_page(
+                            pdf_path,
+                            pi,
+                            dpi=dpi,
+                            languages=langs,
+                            tesseract_cmd=t_cmd,
+                        )
+                        if text_ocr:
+                            text = f"{text}\n{text_ocr}".strip()
                 for rec in _parse_result_lines([ln.strip() for ln in text.splitlines() if ln.strip()], pdf_path):
                     key = (rec["file"], rec["test_name"].lower(), rec.get("value_raw", ""))
                     if key not in seen:

--- a/src/health_report/utils/ocr.py
+++ b/src/health_report/utils/ocr.py
@@ -15,6 +15,7 @@ def ocr_page(
     *,
     dpi: int = DEFAULT_OCR_DPI,
     languages: str = DEFAULT_OCR_LANGS,
+    tesseract_cmd: Optional[str] = None,
 ) -> str:
     """Render a single PDF page to an image and run Tesseract OCR.
 
@@ -24,6 +25,8 @@ def ocr_page(
     try:
         import pypdfium2 as pdfium  # type: ignore
         import pytesseract  # type: ignore
+        if tesseract_cmd:
+            pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
     except ImportError as e:
         logging.debug("OCR dependencies not available: %s", e)
         return ""

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,66 @@
+import pdfplumber
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+import health_report.extract.pdf_parser as pdf_parser
+
+def make_fake_pdf(texts):
+    class FakePage:
+        def __init__(self, text):
+            self._text = text
+        def extract_text(self):
+            return self._text
+        def extract_tables(self):
+            return []
+    class FakePDF:
+        def __init__(self, texts):
+            self.pages = [FakePage(t) for t in texts]
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+    def opener(_):
+        return FakePDF(texts)
+    return opener
+
+def test_ocr_auto_triggers_when_no_text(monkeypatch, tmp_path):
+    monkeypatch.setattr(pdfplumber, "open", make_fake_pdf([""]))
+    called = {}
+    def fake_ocr_page(path, idx, **kwargs):
+        called["called"] = True
+        return "GLUCOSE 81 Reference Range: 65-99 mg/dL"
+    monkeypatch.setattr(pdf_parser, "ocr_page", fake_ocr_page)
+    dummy = tmp_path / "file.pdf"
+    dummy.write_bytes(b"%")
+    rows = pdf_parser.extract_from_pdf(dummy, ocr={"enabled": True, "dpi": 150, "languages": "eng"})
+    assert called.get("called")
+    assert any(r["test_name"] == "GLUCOSE" for r in rows)
+
+def test_ocr_always_runs_even_with_text(monkeypatch, tmp_path):
+    monkeypatch.setattr(pdfplumber, "open", make_fake_pdf(["CHOLESTEROL 200 Reference Range: 0-199 mg/dL"]))
+    calls = []
+    def fake_ocr_page(path, idx, **kwargs):
+        calls.append(1)
+        return "GLUCOSE 81 Reference Range: 65-99 mg/dL"
+    monkeypatch.setattr(pdf_parser, "ocr_page", fake_ocr_page)
+    dummy = tmp_path / "file.pdf"
+    dummy.write_bytes(b"%")
+    rows = pdf_parser.extract_from_pdf(dummy, ocr={"enabled": True, "mode": "always"})
+    # OCR called even though page had text, yielding two measurements
+    assert calls
+    names = {r["test_name"] for r in rows}
+    assert {"CHOLESTEROL", "GLUCOSE"} <= names
+
+def test_ocr_skipped_when_disabled(monkeypatch, tmp_path):
+    monkeypatch.setattr(pdfplumber, "open", make_fake_pdf([""]))
+    called = {}
+    def fake_ocr_page(path, idx, **kwargs):
+        called["called"] = True
+        return ""  # would return text if invoked
+    monkeypatch.setattr(pdf_parser, "ocr_page", fake_ocr_page)
+    dummy = tmp_path / "file.pdf"
+    dummy.write_bytes(b"%")
+    rows = pdf_parser.extract_from_pdf(dummy, ocr={"enabled": False})
+    assert not called
+    assert rows == []


### PR DESCRIPTION
## Summary
- add DPI, language and mode settings under `ocr` config and expose CLI flags
- integrate Tesseract-based OCR fallback in PDF extraction
- document OCR usage and add tests for OCR modes

## Testing
- `pytest tests/test_ocr.py -q`
- `pytest -q` *(fails: test_unitless_alias_arrays)*

------
https://chatgpt.com/codex/tasks/task_e_68c34d5279c4832eb4ce055775c8d397