### PR TITLE
feat: implement time-aware analytics for lab trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A local, offline tool that reads medical lab report PDFs from `reports/`, extrac
 ## Highlights
 - Line‑based extraction tailored for Quest Diagnostics reports ("Reference Range:" lines).
 - Detects per‑measurement units and normalizes to canonical units when possible.
-- Computes simple trends and risk status; renders a clean dashboard.
+- Captures measurement dates and computes time-aware trends and risk status; renders a clean dashboard.
 - All processing is local; PDFs and build outputs are ignored by Git for privacy.
 
 ## Prerequisites
@@ -44,7 +44,7 @@ Edit `config.yaml` to change defaults:
 - `data_dir`: Cache directory (extraction/normalization JSON).
 - `units_preference`: `auto` | `canonical` | `original`.
 - `parsing.cache`: Reuse previous extraction results when available.
-- `analytics.*`: Simple trend and volatility settings.
+- `analytics.*`: Trend and volatility settings, including rolling window, minimum points, and volatility window.
 - `report.title`, `report.favorites`: Dashboard options.
 
 ### OCR

--- a/data/metrics_catalog.json
+++ b/data/metrics_catalog.json
@@ -45,7 +45,7 @@
       "synonyms": ["CHOL/HDLC RATIO", "Cholesterol/HDL Ratio", "Chol/HDL"],
       "category": "lipids",
       "unit_canonical": "",
-      "unit_aliases": [""],
+      "unit_aliases": [],
       "conversions": {},
       "ref_range": {"low": 0, "high": 5.0},
       "emoji": "🧪"
@@ -55,7 +55,7 @@
       "synonyms": ["LDL/HDL RATIO", "LDL to HDL Ratio"],
       "category": "lipids",
       "unit_canonical": "",
-      "unit_aliases": [""],
+      "unit_aliases": [],
       "conversions": {},
       "ref_range": {"low": 0, "high": 3.0},
       "emoji": "🧪"

--- a/src/health_report/analyze/trends.py
+++ b/src/health_report/analyze/trends.py
@@ -1,29 +1,68 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List
+from datetime import datetime, timedelta
 import math
 
 
-def compute_trends(normalized: List[Dict[str, Any]], rolling_window_days: int = 120) -> List[Dict[str, Any]]:
-    # Placeholder: attach simple trend direction based on last 3 values order per test_code
+def compute_trends(
+    normalized: List[Dict[str, Any]],
+    rolling_window_days: int = 120,
+    trend_min_points: int = 3,
+    volatility_window: int = 5,
+) -> List[Dict[str, Any]]:
+    """Compute time-aware trends for normalized measurements.
+
+    Measurements are grouped by ``test_code`` and sorted by ``measured_at``. Only
+    values within ``rolling_window_days`` from the latest measurement are
+    considered. A simple linear regression on day offsets vs. values provides the
+    slope used to determine trend direction.
+    """
+
     by_code: Dict[str, List[Dict[str, Any]]] = {}
     for row in normalized:
-        if row.get("value") is None:
+        if row.get("value") is None or not row.get("measured_at"):
             continue
         by_code.setdefault(row["test_code"], []).append(row)
 
     trends: List[Dict[str, Any]] = []
     for code, rows in by_code.items():
-        vals = [r["value"] for r in rows if r.get("value") is not None]
-        direction = "stable"
-        if len(vals) >= 3:
-            if vals[-1] > vals[-2] > vals[-3]:
+        # Sort by measurement date
+        rows_sorted = sorted(rows, key=lambda r: r["measured_at"])  # ISO date str
+        latest_dt = datetime.fromisoformat(rows_sorted[-1]["measured_at"])
+        window_start = latest_dt - timedelta(days=rolling_window_days)
+        windowed = [
+            r
+            for r in rows_sorted
+            if datetime.fromisoformat(r["measured_at"]) >= window_start
+        ]
+
+        if len(windowed) < trend_min_points:
+            direction = "stable"
+            slope = 0.0
+        else:
+            xs = [datetime.fromisoformat(r["measured_at"]).toordinal() for r in windowed]
+            ys = [r["value"] for r in windowed]
+            n = len(xs)
+            sum_x = sum(xs)
+            sum_y = sum(ys)
+            sum_xx = sum(x * x for x in xs)
+            sum_xy = sum(x * y for x, y in zip(xs, ys))
+            denom = n * sum_xx - sum_x ** 2
+            slope = (n * sum_xy - sum_x * sum_y) / denom if denom else 0.0
+            if slope > 0:
                 direction = "up"
-            elif vals[-1] < vals[-2] < vals[-3]:
+            elif slope < 0:
                 direction = "down"
-        volatility = _std(vals[-5:]) if len(vals) >= 2 else 0.0
-        for r in rows:
-            trends.append({**r, "trend": direction, "volatility": volatility})
+            else:
+                direction = "stable"
+
+        last_vals = [r["value"] for r in windowed[-volatility_window:]]
+        volatility = _std(last_vals) if len(last_vals) >= 2 else 0.0
+
+        for r in windowed:
+            trends.append({**r, "trend": direction, "volatility": volatility, "slope": slope})
+
     return trends
 
 
@@ -32,4 +71,3 @@ def _std(vals: List[float]) -> float:
         return 0.0
     m = sum(vals) / len(vals)
     return math.sqrt(sum((v - m) ** 2 for v in vals) / len(vals))
-

--- a/src/health_report/cli.py
+++ b/src/health_report/cli.py
@@ -52,7 +52,12 @@ def main():
         ocr=cfg.get("ocr", {}),
     )
     normalized = normalize_measurements(extracted, data_dir, units_preference=cfg.get("units_preference", "auto"))
-    trends = compute_trends(normalized, rolling_window_days=cfg.get("analytics", {}).get("rolling_window_days", 120))
+    trends = compute_trends(
+        normalized,
+        rolling_window_days=cfg.get("analytics", {}).get("rolling_window_days", 120),
+        trend_min_points=cfg.get("analytics", {}).get("trend_min_points", 3),
+        volatility_window=cfg.get("analytics", {}).get("volatility_window", 5),
+    )
     scored = compute_scores(trends)
 
     generate_report(

--- a/src/health_report/extract/pdf_parser.py
+++ b/src/health_report/extract/pdf_parser.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Tuple, Optional, Set
 import itertools
 import logging
 import re
+from datetime import datetime
 import pdfplumber
 
 from ..utils.io import read_json, write_json
@@ -12,6 +13,9 @@ from ..utils.ocr import ocr_page, DEFAULT_OCR_DPI, DEFAULT_OCR_LANGS
 
 
 EXTRACT_CACHE = "extracted.json"
+
+# Regex to detect dates like 2023-01-30 or 01/30/2023
+DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4})")
 
 
 def extract_from_reports(reports_dir: Path, data_dir: Path, cache: bool = True, ocr: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
@@ -35,23 +39,10 @@ def extract_from_pdf(pdf_path: Path, ocr: Optional[Dict[str, Any]] = None) -> Li
     rows: List[Dict[str, Any]] = []
     seen: Set[Tuple[str, str, str]] = set()  # (file, name_lower, value_raw)
     try:
+        fallback_date = datetime.fromtimestamp(pdf_path.stat().st_mtime).date().isoformat()
         with pdfplumber.open(pdf_path) as pdf:
+            report_date: Optional[str] = None
             for pi, page in enumerate(pdf.pages):
-                # 1) Parse any table-like blocks by treating cells as text lines
-                tables = page.extract_tables() or []
-                for tbl in tables:
-                    for raw_row in tbl:
-                        for cell in raw_row:
-                            line = (cell or "").strip()
-                            if not line:
-                                continue
-                            for rec in _parse_result_lines([line], pdf_path):
-                                key = (rec["file"], rec["test_name"].lower(), rec.get("value_raw", ""))
-                                if key not in seen:
-                                    rows.append(rec)
-                                    seen.add(key)
-
-                # 2) Also parse raw text lines to catch non-table content
                 text = page.extract_text() or ""
                 if ocr and ocr.get("enabled"):
                     mode = str(ocr.get("mode", "auto")).lower()
@@ -76,7 +67,29 @@ def extract_from_pdf(pdf_path: Path, ocr: Optional[Dict[str, Any]] = None) -> Li
                         )
                         if text_ocr:
                             text = f"{text}\n{text_ocr}".strip()
-                for rec in _parse_result_lines([ln.strip() for ln in text.splitlines() if ln.strip()], pdf_path):
+                if not report_date:
+                    report_date = _find_first_date(text)
+
+                # 1) Parse any table-like blocks by treating cells as text lines
+                tables = page.extract_tables() or []
+                for tbl in tables:
+                    for raw_row in tbl:
+                        for cell in raw_row:
+                            line = (cell or "").strip()
+                            if not line:
+                                continue
+                            for rec in _parse_result_lines([line], pdf_path, default_date=report_date or fallback_date):
+                                key = (rec["file"], rec["test_name"].lower(), rec.get("value_raw", ""))
+                                if key not in seen:
+                                    rows.append(rec)
+                                    seen.add(key)
+
+                # 2) Also parse raw text lines to catch non-table content
+                for rec in _parse_result_lines(
+                    [ln.strip() for ln in text.splitlines() if ln.strip()],
+                    pdf_path,
+                    default_date=report_date or fallback_date,
+                ):
                     key = (rec["file"], rec["test_name"].lower(), rec.get("value_raw", ""))
                     if key not in seen:
                         rows.append(rec)
@@ -89,7 +102,7 @@ def extract_from_pdf(pdf_path: Path, ocr: Optional[Dict[str, Any]] = None) -> Li
     return rows
 
 
-def _parse_result_lines(lines: List[str], pdf_path: Path) -> List[Dict[str, Any]]:
+def _parse_result_lines(lines: List[str], pdf_path: Path, default_date: Optional[str] = None) -> List[Dict[str, Any]]:
     """Parse Quest-style result lines such as:
     - "GLUCOSE 81 Reference Range: 65-99 mg/dL"
     - "HEMOGLOBIN A1c 5.9 H Reference Range: <5.7 % of total Hgb"
@@ -143,6 +156,7 @@ def _parse_result_lines(lines: List[str], pdf_path: Path) -> List[Dict[str, Any]
                 "value_numeric": _extract_numeric(value_raw),
                 "unit_raw": unit_guess or "",
                 "ref_range_raw": f"{rng} {unit_token}".strip(),
+                "measured_at": _find_first_date(ln) or default_date,
             })
             continue
 
@@ -160,6 +174,7 @@ def _parse_result_lines(lines: List[str], pdf_path: Path) -> List[Dict[str, Any]
                 "value_numeric": _extract_numeric(value_raw),
                 "unit_raw": unit_guess or "",
                 "ref_range_raw": "",
+                "measured_at": _find_first_date(ln) or default_date,
             })
             continue
 
@@ -175,6 +190,7 @@ def _parse_result_lines(lines: List[str], pdf_path: Path) -> List[Dict[str, Any]
                 "value_numeric": None,
                 "unit_raw": "",
                 "ref_range_raw": ref,
+                "measured_at": _find_first_date(ln) or default_date,
             })
 
     return out
@@ -253,4 +269,22 @@ def _extract_numeric(s: str) -> float | None:
             return float(m.group(0))
         except Exception:
             return None
+    return None
+
+
+def _find_first_date(text: str) -> Optional[str]:
+    """Return the first date found in ``text`` normalized to ISO format."""
+    m = DATE_RE.search(text)
+    if not m:
+        return None
+    return _parse_date_token(m.group(0))
+
+
+def _parse_date_token(token: str) -> Optional[str]:
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y"):
+        try:
+            dt = datetime.strptime(token, fmt)
+            return dt.date().isoformat()
+        except ValueError:
+            continue
     return None

--- a/src/health_report/normalize/normalize.py
+++ b/src/health_report/normalize/normalize.py
@@ -66,6 +66,7 @@ def normalize_measurements(extracted: List[Dict[str, Any]], data_dir: Path, unit
             "unit_raw": row.get("unit_raw"),
             "ref_low": (tdef.get("ref_range") or {}).get("low"),
             "ref_high": (tdef.get("ref_range") or {}).get("high"),
+            "measured_at": row.get("measured_at"),
         })
 
     write_json(data_dir / NORMALIZED_CACHE, normalized)

--- a/src/health_report/report/generator.py
+++ b/src/health_report/report/generator.py
@@ -22,7 +22,14 @@ def generate_report(*, normalized: List[Dict[str, Any]], trends: List[Dict[str, 
     latest_by_code: Dict[str, Dict[str, Any]] = {}
     for r in scored:
         code = r["test_code"]
-        latest_by_code[code] = r  # naive last-wins; improve with dates when available
+        existing = latest_by_code.get(code)
+        if not existing:
+            latest_by_code[code] = r
+            continue
+        r_dt = r.get("measured_at")
+        e_dt = existing.get("measured_at")
+        if r_dt and (not e_dt or r_dt > e_dt):
+            latest_by_code[code] = r
 
     # Group by category
     by_category: Dict[str, List[Dict[str, Any]]] = defaultdict(list)

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,9 @@
           <div class="value {{ 'status-bad' if r.status=='high' else ('status-warn' if r.status=='low' else 'status-ok') }}">
             {{ r.value }} {{ r.unit }} {{ r.emoji }}
           </div>
-          <div class="muted">{{ r.test_name }} · {{ '↗' if r.trend=='up' else ('↘' if r.trend=='down' else '↔') }}</div>
+          <div class="muted">
+            {{ r.test_name }} · {{ '↗' if r.trend=='up' else ('↘' if r.trend=='down' else '↔') }} {{ r.slope|round(2) }}
+          </div>
         {% else %}
           <div class="muted">No data</div>
         {% endif %}

--- a/tests/test_trends.py
+++ b/tests/test_trends.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from src.health_report.analyze.trends import compute_trends
+
+
+def _extract(code: str, values: list[float], start: str) -> list[dict]:
+    from datetime import datetime, timedelta
+    start_dt = datetime.fromisoformat(start)
+    rows = []
+    for i, val in enumerate(values):
+        rows.append({
+            "test_code": code,
+            "value": val,
+            "measured_at": (start_dt + timedelta(days=i)).date().isoformat(),
+        })
+    return rows
+
+
+def test_compute_trends_upward():
+    data = _extract("A", [1, 2, 3], "2023-01-01")
+    out = compute_trends(data, rolling_window_days=30, trend_min_points=2)
+    latest = out[-1]
+    assert latest["trend"] == "up"
+    assert latest["slope"] > 0
+
+
+def test_compute_trends_downward():
+    data = _extract("B", [3, 2, 1], "2023-01-01")
+    out = compute_trends(data, rolling_window_days=30, trend_min_points=2)
+    latest = out[-1]
+    assert latest["trend"] == "down"
+    assert latest["slope"] < 0
+
+
+def test_compute_trends_insufficient_points():
+    data = _extract("C", [1, 2, 3], "2023-01-01")
+    out = compute_trends(data, rolling_window_days=30, trend_min_points=5)
+    assert out[-1]["trend"] == "stable"
+    assert out[-1]["slope"] == 0


### PR DESCRIPTION
## Summary
- capture measurement dates during PDF extraction and preserve through normalization
- compute time-aware trends with linear regression and configurable windows
- show trend slopes in reports and select latest values by measurement date

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c45cbdc5f8832ea3ddefeacf3cd595